### PR TITLE
Add version number and change documentation link

### DIFF
--- a/custom_components/mojio/manifest.json
+++ b/custom_components/mojio/manifest.json
@@ -1,7 +1,8 @@
 {
   "domain": "mojio",
   "name": "Mojio",
-  "documentation": "https://www.home-assistant.io/integrations/mojio",
+  "documentation": "https://github.com/simontb/mojio-home-assistant",
   "requirements": ["mojio_sdk==0.0.8"],
+  "version": "2022.02.1",
   "codeowners": ["@simontb"]
 }


### PR DESCRIPTION
Version number is a must in any custom_component since 2021.06.X

And updated the documentation link to the GitHub repo.