### PR TITLE
Add scan_interval

### DIFF
--- a/custom_components/mojio/device_tracker.py
+++ b/custom_components/mojio/device_tracker.py
@@ -82,7 +82,7 @@ class MojioDeviceScanner:
             vehicles = self._api.get_vehicles()
             for vehicle in vehicles:
                 last_comp_trip = Trip.get_last_trip(trips, vehicle.mojio_id, True)
-                if last_comp_trip.is_empty:
+                if not last_comp_trip.has_data:
                     last_comp_trip = self._api.get_trip(vehicle.last_trip_id)
                 car_attr = {"VIN": vehicle.getattribute("vin"),
                             "name": vehicle.getattribute("name"),

--- a/custom_components/mojio/manifest.json
+++ b/custom_components/mojio/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "mojio",
   "name": "Mojio",
-  "version": "0.6",
+  "version": "0.7",
   "documentation": "https://github.com/simontb/mojio-home-assistant",
   "requirements": ["mojio_sdk==0.5.0"],
   "codeowners": ["@simontb"]


### PR DESCRIPTION
fixes #13 
Fixes to work with API changes
Allows setting `scan_interval` in `device_tracker.yaml`.  This setting is optional, and the default is 5 min.