### PR TITLE
Fix scan_interval issues

### DIFF
--- a/custom_components/mojio/manifest.json
+++ b/custom_components/mojio/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "mojio",
   "name": "Mojio",
-  "version": "0.7",
+  "version": "0.8",
   "documentation": "https://github.com/simontb/mojio-home-assistant",
   "requirements": ["mojio_sdk==0.5.0"],
   "codeowners": ["@simontb"]


### PR DESCRIPTION
Fixes #16 

- Fix config warning on HA UI
- Change `scan_interval` to seconds.  The default value is `300` seconds.  